### PR TITLE
Ajuste en nombre de la materia, typos y complementos en temas.

### DIFF
--- a/ITS/red.tex
+++ b/ITS/red.tex
@@ -121,7 +121,7 @@
     \node[mat, hyperlink node=pye](pye){Probabilidad y estad\'{\i}stica (3)};\\    
     \node[phy](f4){F\'{\i}sica IV \& lab (4)};\\
     \node[mat](m4){Matem\'{a}ticas IV (3)};\\    
-    \node[com, hyperlink node=at](at){Arquitectura tecnol\'{o}gica (3)};\\
+    \node[com, hyperlink node=at](at){Arquitectura de tecnolog\'{i}a (3)};\\
     \node[pro, hyperlink node=bdd](bdd){Bases de datos (3)};\\\\\\\\
     \node[com, hyperlink node=tydcc](tycdd){Transmisi\'{o}n y comunicaci\'{o}n de datos (3)};\\\\\\
     \node[met, hyperlink node=mdd](mdd){Metodolog\'{\i}as de desarrollo (3)};\\    
@@ -594,28 +594,33 @@ Optativa de s\'{e}ptimo semestre. Tres cr\'{e}ditos. Requiere {\em Optimizaci\'{
 
 \newpage
 
-\hypertarget{at}{\section*{Arquitectura tecnol\'{o}gica}} 
+\hypertarget{at}{\section*{Arquitectura de tecnolog\'{i}a}} 
 
 Cuarto semestre. Tres cr\'{e}ditos. Requiere \hyperlink{sd}{\em Sistemas digitales}.
 
 \begin{itemize}
 \item{Instrucciones y procesadores}
-\item{Yerarqu\'{i}a de memoria}
+\item{Jerarqu\'{i}a de memoria}
 \item{Memoria virtual}
 \item{Almacenaje en discos}
 \item{Desempe\~{n}o de entrada y salida}
 \item{Arquitectura de software}
-\item{Requerimientos y atributos de calidad}
-\item{Estilos arquitect\'{o}nicos; arquitectura limpia}
-\item{Principios de dise\~{n}o}
-\item{Software como servicio, microservicios}
+\item{Requerimientos funcionales, t\'{e}cnicos y atributos de calidad}
+\item{Estilos de arquitectura}
+\item{Patrones de dise\~{n}o}
+\item{Arquitectura de tiempo de ejecuci\'{o}n}
+\item{Arquitectura de desarrollo}
+\item{Arquitectura de aplicaci\'{o}n}
+\item{Arquitectura de datos}
+\item{Arquitectura de seguridad}
+\item{Arquitectura de infraestructura}
 \end{itemize}
 
 \vfill\null \columnbreak
 
 \hypertarget{so}{\section*{Sistemas operativos}}  
 
-Quinto semestre. Cuatro cr\'{e}ditos. Requiere {\em Arquitectura tecnol\'{o}gica}.
+Quinto semestre. Cuatro cr\'{e}ditos. Requiere {\em Arquitectura de tecnolog\'{i}a}.
 
 \begin{itemize}
 \item{Procesos e hilos}


### PR DESCRIPTION
1. Ajuste en nombre de la materia. En inglés el término es "technology architecture", no "technological architecture", entonces en español sería: arquitectura de tecnología.
2. Fixed typo en "Jerarquía de memoria".
3. En requerimientos, le agregué lo de funcionales y técnicos.
4. Estilos, lo cambie a "Estilos de arquitectura", misma lógica que con el nombre de la materia. Y le quité lo de "arquitectura limpia" porque ese es sólo un estilo, hay más.
5. Principios de diseño lo quité porque ese puede ir como intro en tanto "Estilos de arquitectura" y "Patrones de diseño".
6. "Software como servicio, microservicios" lo quité porque software como servicio es otra cosa, eso es un término oficial dentro del tema de cloud (IaaS, PaaS, SaaS). Además, microservicios va dentro de estilos de arquitectura.
7. Añadí al final las principales arquitecturas de tecnología a considerar en una solución.